### PR TITLE
don't tag alpha/rc etc latest

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,6 +23,11 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: compasrrc/compas_rrc_driver
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Realized that if a tag such as v1.2.3-alpha would be pushed to git then this workflow would tag that as latest image and push to dockerhub.

Since latest on dockerhub basically means latest **stable** that would not make sense. I've added tags to the docker/metadata-action action copied from their [semver example](https://github.com/docker/metadata-action#semver).

Here's a copy of the table they provide to explain output tags:

| Event           | Ref                           | Docker Tags                         |
|-----------------|-------------------------------|-------------------------------------|
| `pull_request`  | `refs/pull/2/merge`           | `pr-2`                              |
| `push`          | `refs/heads/master`           | `master`                            |
| `push`          | `refs/heads/releases/v1`      | `releases-v1`                       |
| `push tag`      | `refs/tags/v1.2.3`            | `1.2.3`, `1.2`, `latest`            |
| `push tag`      | `refs/tags/v2.0.8-beta.67`    | `2.0.8-beta.67`                     |