### PR TITLE
use v prefix for docker image tags

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,8 +26,8 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Last push to docker created 1.1, 1.3 and latest. It should have created v1.1, v1.3 and latest to keep with previous releases. It might be prudent to fix this on dockerhub by pushing manually with correct tags.